### PR TITLE
On Windows, pressing C-e after :SVNStatus doesn't mark any lines

### DIFF
--- a/autoload/svnj/select.vim
+++ b/autoload/svnj/select.vim
@@ -137,7 +137,9 @@ endf
 
 fun! s:resignselect(line, key, linenum, cmdpost, selcnt)
     if !has_key(s:selectd, a:key) | retur a:selcnt | en
-    if matchstr(a:line, s:selectd[a:key].line) == ""  | retur a:selcnt | en
+    let line = substitute(a:line, '\\', '/', 'g')
+    let selectdline = substitute(s:selectd[a:key].line, '\\', '/', 'g')
+    if matchstr(line, selectdline) == ""  | retur a:selcnt | en
     exe 'silent! sign place ' . a:key . ' line=' . a:linenum . a:cmdpost
     retu a:selcnt - 1
 endf

--- a/autoload/svnj/select.vim
+++ b/autoload/svnj/select.vim
@@ -137,9 +137,8 @@ endf
 
 fun! s:resignselect(line, key, linenum, cmdpost, selcnt)
     if !has_key(s:selectd, a:key) | retur a:selcnt | en
-    let line = substitute(a:line, '\\', '/', 'g')
-    let selectdline = substitute(s:selectd[a:key].line, '\\', '/', 'g')
-    if matchstr(line, selectdline) == ""  | retur a:selcnt | en
+    let selectdline = '\V' . substitute(s:selectd[a:key].line, '\\', '\\\\', 'g')
+    if matchstr(a:line, selectdline) == ""  | retur a:selcnt | en
     exe 'silent! sign place ' . a:key . ' line=' . a:linenum . a:cmdpost
     retu a:selcnt - 1
 endf


### PR DESCRIPTION
C-e is the shortcut for SelectAll. The mark I'm referring to is the `s>` mark that goes on selected lines. This appears to be merely a visual issue since a C-z (Commit) does commit all files afterwards, even if they don't have the `s>` mark.

The patch does not affect execution on Linux as far as I can tell (backslashes are converted to forward slashes on both sides). The issue appears to be that a backslash causes the following character to become special, but then
```VimL
let line = substitute(a:line, '\\', '\\\\', 'g')
let selectdline = substitute(s:selectd[a:key].line, '\\', '\\\\', 'g')
```
does not work here.